### PR TITLE
feat: add headers to response data + add to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ async fn main() -> Result<(), TweetyError> {
 }
 ```
 
+# ⚠️ Responses
+
+We return the response together with the headers if that might be important to you. The structure is as show in the struct below:
+
+```rust
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ResponseWithHeaders {
+        pub response: Value,
+        pub headers: HashMap<String, String>,
+    }
+```
+
+
 # ⚠️ Twitter API Rate Limits
 
 Twitter has a small window cap for the free tier, so it's important to be aware of the rate limits.

--- a/src/api/bookmark.rs
+++ b/src/api/bookmark.rs
@@ -1,8 +1,8 @@
 use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::types::types::ResponseWithHeaders;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -126,13 +126,16 @@ pub struct BookmarkParams {
 impl TweetyClient {
     /// Bookmarks lookup
     /// Lookup a user's Bookmarks
-    pub async fn get_user_bookmark(self, user_id: &str) -> Result<Value, TweetyError> {
+    pub async fn get_user_bookmark(
+        self,
+        user_id: &str,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/bookmarks", user_id);
 
         self.send_request::<()>(&url, Method::GET, None).await
     }
     /// Bookmark a Post
-    pub async fn bookmark_post(self, post_id: &str) -> Result<Value, TweetyError> {
+    pub async fn bookmark_post(self, post_id: &str) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/bookmarks", post_id);
 
         self.send_request::<()>(&url, Method::POST, None).await
@@ -142,7 +145,7 @@ impl TweetyClient {
         self,
         user_id: &str,
         tweet_id: &str,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/users/{}/bookmarks/{}",
             user_id, tweet_id

--- a/src/api/direct_messages.rs
+++ b/src/api/direct_messages.rs
@@ -1,8 +1,7 @@
 use super::error::TweetyError;
-use crate::TweetyClient;
+use crate::{types::types::ResponseWithHeaders, TweetyClient};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -200,7 +199,10 @@ impl TweetyClient {
     /// Supports retrieving events from the previous 30 days.
     /// Authentication methods supported by this endpoint
     // OAuth 2.0 Authorization Code with PKCE
-    pub async fn get_direct_messages(&self, params: QueryParams) -> Result<Value, TweetyError> {
+    pub async fn get_direct_messages(
+        &self,
+        params: QueryParams,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/dm_events?{}", params.to_query_string());
         self.send_request::<()>(&url, Method::GET, None).await
     }
@@ -212,7 +214,7 @@ impl TweetyClient {
         &self,
         participant_id: &str,
         params: QueryParams,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/dm_conversations/with/{}/dm_events?{}",
             participant_id,
@@ -227,7 +229,7 @@ impl TweetyClient {
         &self,
         dm_conversation_id: &str,
         params: QueryParams,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/dm_conversations/{}/dm_events?{}",
             dm_conversation_id,

--- a/src/api/followers.rs
+++ b/src/api/followers.rs
@@ -1,5 +1,5 @@
 use super::{error::TweetyError, user::UserQueryParams};
-use crate::api::client::TweetyClient;
+use crate::{api::client::TweetyClient, types::types::ResponseWithHeaders};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,7 @@ impl TweetyClient {
         &self,
         user_id: &str,
         params: Option<UserQueryParams>,
-    ) -> Result<UserFollowersResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut url = format!("https://api.x.com/2/users/{}/followers?", user_id);
 
         if let Some(param_str) = params {
@@ -37,10 +37,7 @@ impl TweetyClient {
             url.push_str(&query_string);
         }
         match self.send_request::<()>(&url, Method::GET, None).await {
-            Ok(value) => match serde_json::from_value::<UserFollowersResponse>(value) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(TweetyError::JsonParseError(err.to_string())),
-            },
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }

--- a/src/api/following.rs
+++ b/src/api/following.rs
@@ -1,6 +1,6 @@
 use super::user::UserQueryParams;
-use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::{api::client::TweetyClient, types::types::ResponseWithHeaders};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
@@ -92,7 +92,7 @@ impl TweetyClient {
         &self,
         user_id: &str,
         target_user_id: &str,
-    ) -> Result<FollowResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/:{}/following", user_id);
 
         let json_body = FollowBody {
@@ -100,10 +100,7 @@ impl TweetyClient {
         };
 
         match self.send_request(&url, Method::POST, Some(json_body)).await {
-            Ok(value) => match serde_json::from_value::<FollowResponse>(value) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(TweetyError::JsonParseError(err.to_string())),
-            },
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }
@@ -115,17 +112,14 @@ impl TweetyClient {
         &self,
         source_userid: &str,
         target_userid: &str,
-    ) -> Result<UnfollowResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/users/:{}/following/:{}",
             source_userid, target_userid
         );
 
         match self.send_request::<()>(&url, Method::DELETE, None).await {
-            Ok(value) => match serde_json::from_value::<UnfollowResponse>(value) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(TweetyError::JsonParseError(err.to_string())),
-            },
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }
@@ -136,7 +130,7 @@ impl TweetyClient {
         &self,
         user_id: &str,
         query: Option<UserQueryParams>,
-    ) -> Result<UserFollowingResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut base_url = format!("https://api.x.com/2/users/{}/following", user_id);
 
         if let Some(query) = query {
@@ -145,10 +139,7 @@ impl TweetyClient {
         }
 
         match self.send_request::<()>(&base_url, Method::GET, None).await {
-            Ok(value) => match serde_json::from_value::<UserFollowingResponse>(value) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(TweetyError::JsonParseError(err.to_string())),
-            },
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }

--- a/src/api/hide_replies.rs
+++ b/src/api/hide_replies.rs
@@ -1,8 +1,7 @@
-use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::{api::client::TweetyClient, types::types::ResponseWithHeaders};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HideTweet {
@@ -16,7 +15,7 @@ pub struct HideTweet {
 /// https://api.x.com/2/tweets/:id/hidden
 /// hidden	boolean	Indicates if the Tweet was successfully hidden or unhidden.
 impl TweetyClient {
-    pub async fn hide_tweet(self, tweet_id: &str) -> Result<Value, TweetyError> {
+    pub async fn hide_tweet(self, tweet_id: &str) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/tweets/{}/hidden", tweet_id);
         let json_body = HideTweet { hidden: true };
         self.send_request(&url, Method::PUT, Some(json_body)).await

--- a/src/api/like.rs
+++ b/src/api/like.rs
@@ -1,13 +1,17 @@
 use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::types::types::ResponseWithHeaders;
 use reqwest::Method;
-use serde_json::Value;
 
 impl TweetyClient {
     /// DELETE https://api.x.com/2/tweets/:id/likes/:tweet_id
     /// (unlike a Post)
     /// https://developer.x.com/en/docs/x-api/tweets/likes/migrate/manage-likes-standard-to-twitter-api-v2
-    pub async fn unlike_tweet(&self, user_id: u64, tweet_id: u64) -> Result<Value, TweetyError> {
+    pub async fn unlike_tweet(
+        &self,
+        user_id: u64,
+        tweet_id: u64,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/tweets/:{}/likes/:{}",
             user_id, tweet_id
@@ -17,7 +21,10 @@ impl TweetyClient {
     }
     /// Users who have liked a Post
     /// https://developer.x.com/en/docs/x-api/tweets/likes/api-reference
-    pub async fn get_users_who_liked_a_post(&self, post_id: &str) -> Result<Value, TweetyError> {
+    pub async fn get_users_who_liked_a_post(
+        &self,
+        post_id: &str,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/tweets/{}/liking_users", post_id);
 
         self.send_request::<()>(&url, Method::GET, None).await
@@ -25,7 +32,10 @@ impl TweetyClient {
 
     /// Posts liked by a user
     /// https://developer.x.com/en/docs/x-api/tweets/likes/api-reference
-    pub async fn get_posts_liked_by_a_user(&self, user_id: &str) -> Result<Value, TweetyError> {
+    pub async fn get_posts_liked_by_a_user(
+        &self,
+        user_id: &str,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/liked_tweets", user_id);
 
         self.send_request::<()>(&url, Method::GET, None).await
@@ -34,7 +44,7 @@ impl TweetyClient {
 
     /// Allows a user ID to like a Post
     /// https://developer.x.com/en/docs/x-api/tweets/likes/api-reference
-    pub async fn like_a_post(&self, user_id: &str) -> Result<Value, TweetyError> {
+    pub async fn like_a_post(&self, user_id: &str) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/likes", user_id);
 
         self.send_request::<()>(&url, Method::POST, None).await
@@ -42,7 +52,11 @@ impl TweetyClient {
 
     /// Allows a user ID to unlike a Post
     /// https://developer.x.com/en/docs/x-api/tweets/likes/api-reference
-    pub async fn unlike_a_post(&self, user_id: &str, tweet_id: &str) -> Result<Value, TweetyError> {
+    pub async fn unlike_a_post(
+        &self,
+        user_id: &str,
+        tweet_id: &str,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/likes/{}", user_id, tweet_id);
 
         self.send_request::<()>(&url, Method::DELETE, None).await

--- a/src/api/mentions.rs
+++ b/src/api/mentions.rs
@@ -1,5 +1,5 @@
-use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::{api::client::TweetyClient, types::types::ResponseWithHeaders};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_qs::to_string as convert_query_to_string;
@@ -240,17 +240,14 @@ impl TweetyClient {
         &self,
         user_id: &str,
         query_params: Option<QueryParams>,
-    ) -> Result<MentionsResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut base_url = format!("https://api.x.com/2/users/{}/mentions", user_id);
         if let Some(queries) = query_params {
             let query_params = convert_query_to_string(&queries).unwrap();
             base_url = format!("{}?{}", base_url, query_params);
         }
         match self.send_request::<()>(&base_url, Method::GET, None).await {
-            Ok(value) => match serde_json::from_value::<MentionsResponse>(value) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(TweetyError::JsonParseError(err.to_string())),
-            },
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }

--- a/src/api/retweets.rs
+++ b/src/api/retweets.rs
@@ -1,7 +1,7 @@
 use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::types::types::ResponseWithHeaders;
 use reqwest::Method;
-use serde_json::Value;
 
 /// Check required params
 /// [Docs](https://developer.x.com/en/docs/x-api/tweets/retweets/api-reference/get-tweets-id-retweets#tab0)
@@ -57,12 +57,15 @@ impl RetweetQueryParams {
 
 impl TweetyClient {
     /// Users who have Retweeted a Post
-    pub async fn fetch_retweeters(self, tweet_id: &str) -> Result<Value, TweetyError> {
+    pub async fn fetch_retweeters(
+        self,
+        tweet_id: &str,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/tweets/{}/retweeted_by", tweet_id);
         self.send_request::<()>(&url, Method::GET, None).await
     }
     /// Causes the user ID identified in the path parameter to Retweet the target Tweet.
-    pub async fn retweet(&self, tweet_id: &str) -> Result<Value, TweetyError> {
+    pub async fn retweet(&self, tweet_id: &str) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!("https://api.x.com/2/users/{}/retweets", tweet_id);
         self.send_request::<()>(&url, Method::POST, None).await
     }
@@ -74,7 +77,7 @@ impl TweetyClient {
         &self,
         user_id: &str,
         source_tweet_id: &str,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/users/{}/retweets/{}",
             user_id, source_tweet_id
@@ -89,7 +92,7 @@ impl TweetyClient {
         self,
         user_id: &str,
         params: Option<RetweetQueryParams>,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut url = format!("https://api.x.com/2/tweets/{}/retweets", user_id);
 
         if let Some(query_params) = params {

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,8 +1,8 @@
 use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::types::types::ResponseWithHeaders;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use serde_qs::to_string as query_string;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -316,7 +316,7 @@ impl TweetyClient {
         &self,
         query: &str,
         query_params: Option<QueryParams>,
-    ) -> Result<RecentSearchResponse, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut base_url = format!("https://api.x.com/2/tweets/search/recent?query={}", query);
 
         if let Some(value) = query_params {
@@ -324,15 +324,7 @@ impl TweetyClient {
         }
 
         match self.send_request::<()>(&base_url, Method::GET, None).await {
-            Ok(value) => {
-                let json_data = serde_json::from_value::<RecentSearchResponse>(value);
-
-                if let Ok(data) = json_data {
-                    Ok(data)
-                } else {
-                    Err(TweetyError::JsonParseError("Invalid JSON".to_string()))
-                }
-            }
+            Ok(value) => Ok(value),
             Err(err) => Err(TweetyError::ApiError(err.to_string())),
         }
     }
@@ -345,7 +337,7 @@ impl TweetyClient {
         &self,
         query: &str,
         query_params: Option<QueryParams>,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let mut base_url = format!("https://api.x.com/2/tweets/search/all?query={}", query);
 
         if let Some(queries) = query_params {

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -8,10 +8,10 @@
 
 use crate::api::client::TweetyClient;
 use crate::api::error::TweetyError;
+use crate::types::types::ResponseWithHeaders;
 use crate::types::user::UserResponse;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UserInfo {
@@ -157,7 +157,7 @@ impl TweetyClient {
         &self,
         user_id: &str,
         params: Option<UserQueryParams>,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let query_string = if let Some(params) = params {
             params.construct_query_string()
         } else {
@@ -174,7 +174,7 @@ impl TweetyClient {
         &self,
         ids: Vec<String>,
         params: Option<UserQueryParams>,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let ids_string = ids.join(",");
         let query_string = if let Some(params) = params {
             params.construct_query_string()
@@ -191,7 +191,10 @@ impl TweetyClient {
     ///  Returns a variety of information about one or more users specified by their usernames.
     ///  Required 	string	A comma separated list of user IDs. Up to 100 are allowed in a single request.
     /// Make sure to not include a space between commas and fields.
-    pub async fn get_users_by_username(&self, username: &[&str]) -> Result<Value, TweetyError> {
+    pub async fn get_users_by_username(
+        &self,
+        username: &[&str],
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let url = format!(
             "https://api.x.com/2/users/by/username/{}",
             username.join(",")
@@ -207,7 +210,7 @@ impl TweetyClient {
         &self,
         user_names: &[&str],
         params: Option<UserQueryParams>,
-    ) -> Result<Value, TweetyError> {
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let query_string = if let Some(params) = params {
             params.construct_query_string()
         } else {
@@ -224,7 +227,10 @@ impl TweetyClient {
     }
     /// Returns information about an authorized user.
     /// <https://developer.x.com/en/docs/x-api/users/lookup/api-reference/get-users-me#>
-    pub async fn get_user_me(&self, params: Option<UserQueryParams>) -> Result<Value, TweetyError> {
+    pub async fn get_user_me(
+        &self,
+        params: Option<UserQueryParams>,
+    ) -> Result<ResponseWithHeaders, TweetyError> {
         let query_string = if let Some(params) = params {
             params.construct_query_string()
         } else {

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Struct provided by TwitterBot methods
 #[derive(Debug, Serialize, Deserialize)]
@@ -116,4 +119,10 @@ pub struct TweetInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TweetResponse {
     pub data: TweetInfo,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResponseWithHeaders {
+    pub response: Value,
+    pub headers: HashMap<String, String>,
 }


### PR DESCRIPTION
- Added headers to the response data
- Updated the docs on the same and how to retrieve the headers
- This PR will return all the headers returned from the Twitter API into a HashMap.